### PR TITLE
Adds Prompt.Select(question, options);

### DIFF
--- a/src/Ninquirer.Demo/Program.cs
+++ b/src/Ninquirer.Demo/Program.cs
@@ -73,7 +73,17 @@ namespace Ninquirer.Demo
             );
 
             Prompt.PressAnyKeyToContinue(true);
-            console.WriteLine("👻 🎃 😱");
+            console.WriteLine("// 👻 🎃 😱");
+
+            var color = Prompt.Select(
+                "What is your favourite colour?",
+                Enum.GetValues(typeof(ConsoleColor))
+                    .Cast<ConsoleColor>()
+                    .Select(x => x.ToString())
+                    .ToArray()
+                );
+
+            Console.WriteLine($"// You selected {color}!");
         }
     }
 }

--- a/src/Ninquirer.Tests/Builders/ConsoleMockBuilder.cs
+++ b/src/Ninquirer.Tests/Builders/ConsoleMockBuilder.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using Moq;
 using Ninquirer.Internal;
 
@@ -13,6 +14,9 @@ namespace Ninquirer.Tests.Builders
             _inputSequence = inputSequence;
             return this;
         }
+
+        public ConsoleMockBuilder WithReadKeySequence(params ConsoleKey[] inputSequence)
+            => WithReadKeySequence(inputSequence.Select(x => (char)x).ToArray());
 
         public Mock<IColoredConsole> Build()
         {

--- a/src/Ninquirer.Tests/Internal/SelectTests.cs
+++ b/src/Ninquirer.Tests/Internal/SelectTests.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Linq;
+using Ninquirer.Tests.Builders;
+using NUnit.Framework;
+
+namespace Ninquirer.Internal.Tests
+{
+    public class SelectTests
+    {
+        [TestCase(
+            new[] { ConsoleKey.DownArrow, ConsoleKey.DownArrow, ConsoleKey.Enter },
+            new[] { "a", "b", "c", "d", "e", "f" },
+            ExpectedResult = "c")]
+        [TestCase(
+            new[] { ConsoleKey.DownArrow, ConsoleKey.UpArrow, ConsoleKey.Enter },
+            new[] { "a", "b", "c", "d", "e", "f" },
+            ExpectedResult = "a")]
+        [TestCase(
+            new[] { ConsoleKey.Enter },
+            new[] { "a", "b", "c", "d", "e", "f" },
+            ExpectedResult = "a")]
+        [TestCase(
+            new[] { ConsoleKey.UpArrow, ConsoleKey.Enter },
+            new[] { "a", "b", "c", "d", "e", "f" },
+            ExpectedResult = "f")]
+        public string Select(ConsoleKey[] inputSequence, string[] options)
+        {
+            if (!inputSequence.Contains(ConsoleKey.Enter))
+            {
+                Assert.Fail(@"Invalid input sequence for this test,
+there needs to be a Enter. Otherwise the the test will hang");
+            }
+
+            var consoleMock = new ConsoleMockBuilder()
+                .WithReadKeySequence(inputSequence)
+                .Build();
+
+            Select sut = new Select(consoleMock.Object);
+
+            return sut.Ask("Test Question??", options);
+        }
+    }
+}

--- a/src/Ninquirer/Internal/ColoredConsole.cs
+++ b/src/Ninquirer/Internal/ColoredConsole.cs
@@ -5,6 +5,10 @@ namespace Ninquirer.Internal
 
     public class ColoredConsole : IColoredConsole
     {
+        public int CursorTop => Console.CursorTop;
+
+        public int WindowWidth => Console.WindowWidth;
+
         public void Write(params (string message, ConsoleColor? color)[] messages)
         {
             foreach ((string message, ConsoleColor? color) in messages)
@@ -40,5 +44,8 @@ namespace Ninquirer.Internal
         }
 
         public ConsoleKeyInfo ReadKey() => Console.ReadKey(true);
+
+        public void SetCursorPosition(int left, int top)
+            => Console.SetCursorPosition(left, top);
     }
 }

--- a/src/Ninquirer/Internal/IColoredConsole.cs
+++ b/src/Ninquirer/Internal/IColoredConsole.cs
@@ -15,5 +15,11 @@ namespace Ninquirer.Internal
         void Backspace(int length);
 
         ConsoleKeyInfo ReadKey();
+
+        void SetCursorPosition(int left, int top);
+
+        int CursorTop { get; }
+
+        int WindowWidth { get; }
     }
 }

--- a/src/Ninquirer/Internal/Select.cs
+++ b/src/Ninquirer/Internal/Select.cs
@@ -1,0 +1,68 @@
+
+using System;
+using System.Linq;
+
+namespace Ninquirer.Internal
+{
+    public class Select
+    {
+        private readonly IColoredConsole _console;
+
+        private static ConsoleKey[] nextKeys = new[] { ConsoleKey.Tab, ConsoleKey.DownArrow, ConsoleKey.J };
+        private static ConsoleKey[] previousKeys = new[] { ConsoleKey.UpArrow, ConsoleKey.K };
+
+        public Select(IColoredConsole console)
+            => _console = console ?? throw new ArgumentNullException(nameof(console));
+
+        public string Ask(string question, params string[] options)
+        {
+            if (options == null) { throw new ArgumentNullException(nameof(options)); }
+            if (options.Length == 0) { throw new ArgumentOutOfRangeException(nameof(options)); }
+
+            bool isEnterKey(ConsoleKeyInfo? info) => info?.Key == ConsoleKey.Enter;
+            ConsoleKeyInfo input;
+            int index = 0;
+
+            do
+            {
+                _console.Write(
+                    ("\r? ", ConsoleColor.Green),
+                    (question, default)
+                );
+                _console.Write(
+                    options.Select((option, i) => ($"\n •{option} ", i == index ? ConsoleColor.DarkGreen : (ConsoleColor?)default))
+                    .ToArray()
+                );
+                input = _console.ReadKey();
+
+                index = input switch
+                {
+                    { Key: var key } when nextKeys.Contains(key) => (index + 1) % options.Length,
+                    { Key: var key } when previousKeys.Contains(key) => (index - 1 + options.Length) % options.Length,
+                    _ => index
+                };
+
+                _console.SetCursorPosition(0, _console.CursorTop - options.Length);
+
+            } while (!isEnterKey(input));
+
+            _console.Write(
+                ("\r? ", ConsoleColor.Green),
+                (question, default),
+                ($" {options[index]}", ConsoleColor.Green)
+            );
+
+            // Hack to "clear" the list of options shown
+            // This overwrites all the lines with whitespace.
+            // This is a hack because the lines are not truly cleared to empty.
+            _console.Write(
+                options.Select((option, i) => ($"\n{new string(' ', _console.WindowWidth)}", (ConsoleColor?)default))
+                .ToArray()
+            );
+
+            _console.SetCursorPosition(0, _console.CursorTop - options.Length + 1);
+
+            return options[index];
+        }
+    }
+}

--- a/src/Ninquirer/Ninquirer.csproj
+++ b/src/Ninquirer/Ninquirer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <NullableReferenceTypes>true</NullableReferenceTypes>
   </PropertyGroup>

--- a/src/Ninquirer/Prompt.cs
+++ b/src/Ninquirer/Prompt.cs
@@ -8,7 +8,10 @@ namespace Ninquirer
         private static IColoredConsole _console = new ColoredConsole();
         private static Confirm _confirm = new Confirm(_console);
         private static PressAnyKeyToContinue _pressAnyKeyToContiner = new PressAnyKeyToContinue(_console);
+        private static Select _select = new Select(_console);
+
         public static bool Confirm(string message) => _confirm.Ask(message);
         public static void PressAnyKeyToContinue(bool hideResult = false) => _pressAnyKeyToContiner.Ask(hideResult);
+        public static string Select(string question, params string[] options) => _select.Ask(question, options);
     }
 }


### PR DESCRIPTION
The hard part with this input is overwriting the output to allow the
console to update the text in place without scrolling the terminal using
Console.Clear();

Once an option has been selected overwriting all lines for each option with whitespace seems to
be the only solution. I would like to be able to use a special control charcter, but given the
unknown enviroment this could be running in, windows, linux etc I guess this is hard.
We are lucky new lines and returns work 