### PR TITLE
Updates press any key to cover more cases

### DIFF
--- a/src/Ninquirer.Tests/Internal/PressAnyKeyToContinueTests.cs
+++ b/src/Ninquirer.Tests/Internal/PressAnyKeyToContinueTests.cs
@@ -1,4 +1,4 @@
-using AutoFixture.NUnit3;
+using System;
 using Ninquirer.Tests.Builders;
 using NUnit.Framework;
 
@@ -6,8 +6,8 @@ namespace Ninquirer.Internal.Tests
 {
     public class PressAnyKeyToContinueTests
     {
-        [Test, AutoData]
-        public void AllKeysContinue(char input)
+        [Test]
+        public void AllKeysContinue([Values]ConsoleKey input)
         {
             var consoleMock = new ConsoleMockBuilder()
                 .WithReadKeySequence(input)


### PR DESCRIPTION
Replaced autofixture usage with enumerate all values in the enum using builtin NUnit. 
Given the sample space of this I think this is a better fit.

----

If the sample space was a lot larger autofixture would be a better fit, but since this is
small enough we can hit all of these known key inputs I think this is a better trade off.